### PR TITLE
Add gcc to muslPath

### DIFF
--- a/mkGraal.nix
+++ b/mkGraal.nix
@@ -48,7 +48,7 @@ let
     ++ lib.optionals gtkSupport [ cairo glib gtk3 ];
 
   muslPath = lib.makeBinPath [
-    musl.dev
+    musl.dev gcc
     # GraalVM 21.3.0+ expects musl-gcc as <system>-musl-gcc
     (writeShellScriptBin "${stdenv.system}-musl-gcc" ''${musl.dev}/bin/musl-gcc "$@"'')
   ];


### PR DESCRIPTION
@thiagokokada I'm not sure if this is the correct fix, but it made the static musl build work for me.